### PR TITLE
Fix for new discord urls

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -35,4 +35,4 @@ jobs:
           context: .
           platforms: linux/amd64
           push: ${{ github.event_name != 'pull_request' }}
-          tags: ghcr.io/fg-devs/attachment-service:latest
+          tags: ghcr.io/survivalquestmc/attachment-service:latest

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -66,6 +66,7 @@ dependencies = [
  "tower-http 0.2.5",
  "tracing",
  "tracing-subscriber",
+ "url",
  "uuid",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,6 +21,7 @@ tower-http = { version = "0.2.5", features = ["fs", "trace"] }
 tracing = "0.1.34"
 tracing-subscriber = { version = "0.3.11", features = ["env-filter"] }
 uuid = { version = "0.8.2", features = ["v4"] }
+url = "2.2.2"
 
 [build-dependencies]
 tonic-build = "0.7.0"

--- a/src/grpc/attachments.rs
+++ b/src/grpc/attachments.rs
@@ -28,7 +28,7 @@ impl Attachments for ImplementedAttachmentsServer {
         debug!("finished parsing url: {}", file_url);
 
         // remove if broken
-        file_url = file_url.split('?').next().unwrap_or(file_url);
+        file_url = file_url.split('?').next().unwrap_or(file_url).to_string();
 
         let ext = Files::get_extension(&file_url)?;
         let bytes = Files::fetch(&file_url).await?;

--- a/src/grpc/attachments.rs
+++ b/src/grpc/attachments.rs
@@ -28,7 +28,7 @@ impl Attachments for ImplementedAttachmentsServer {
         debug!("finished parsing url: {}", file_url);
 
         // remove if broken
-        file_url = file_url.split('?').next().unwrap_or(file_url).to_string();
+        file_url = file_url.split('?').next().unwrap_or(file_url.as_str());
 
         let ext = Files::get_extension(&file_url)?;
         let bytes = Files::fetch(&file_url).await?;

--- a/src/grpc/attachments.rs
+++ b/src/grpc/attachments.rs
@@ -27,6 +27,9 @@ impl Attachments for ImplementedAttachmentsServer {
         let file_url = request.into_inner().url;
         debug!("finished parsing url: {}", file_url);
 
+        // remove if broken
+        file_url = file_url.split('?').next().unwrap_or(file_url);
+
         let ext = Files::get_extension(&file_url)?;
         let bytes = Files::fetch(&file_url).await?;
         info!("fetched attachment: {}", file_url);


### PR DESCRIPTION
Discord started using extra params that was resulting in a 404 when image was uploaded with params included in file name but the GET was still referencing without the params.

This fix will strip extra params before processing